### PR TITLE
Correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Library for communication with Gira Dual Q RF Module
 paragraph=Like this project? Please star it on GitHub!
 category=Device Control
 url=https://github.com/metaneutrons/girf/
-architectures=all
+architectures=*


### PR DESCRIPTION
The previous architectures value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library girf claims to run on (ARCHITECTURE) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```
The previous architectures value caused the library's examples to be placed under the File > Examples > INCOMPATIBLE menu.