### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,10 +13,10 @@ girf	KEYWORD1
 setup	KEYWORD2
 loop	KEYWORD2
 SetOnDebugHandler	KEYWORD2
-SetOnAlarmHandler   KEYWORD2
-SetOnAlarmTestHandler   KEYWORD2
-SetOnBatteryWarningHandler  KEYWORD2
-send_message    KEYWORD2
+SetOnAlarmHandler	KEYWORD2
+SetOnAlarmTestHandler	KEYWORD2
+SetOnBatteryWarningHandler	KEYWORD2
+send_message	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords