### PR TITLE
feat: support sending alarm/testalarm

### DIFF
--- a/src/girf.cpp
+++ b/src/girf.cpp
@@ -358,6 +358,22 @@ void girf::process_byte(char c) {
   }
 }
 
+void girf::SetLocalAlarm( bool status ){
+  #ifdef GIRF_DEBUG
+    debug("Setting local Alarm");
+  #endif
+  _status_alarm_local = status;
+  send_status( false );
+}
+
+void girf::SetLocalTestAlarm( bool status ){
+  #ifdef GIRF_DEBUG
+    debug("Setting local Test Alarm");
+  #endif
+  _status_alarm_local_test = status;
+  send_status( false );
+}
+
 void girf::loop() {
 
   if ((cmd_send_counter == 1) ||

--- a/src/girf.h
+++ b/src/girf.h
@@ -68,6 +68,8 @@ public:
   void SetOnAlarmHandler(void (*func)(bool));
   void SetOnAlarmTestHandler(void (*func)(bool));
   void SetOnBatteryWarningHandler(void (*func)(bool));
+  void SetLocalAlarm(bool status);
+  void SetLocalTestAlarm(bool status);
   void loop();
   // public variables
 


### PR DESCRIPTION
Hallo Fabian,

danke für die Unterstützung nochmals!
Hier wie abgesprochen die Funktion um vom simulierten Rauchmelder Alarme/Testalarme auszulösen.
